### PR TITLE
chore: use datetime cast instead of dates array

### DIFF
--- a/src/Commands/stubs/subscription_model_l7.stub
+++ b/src/Commands/stubs/subscription_model_l7.stub
@@ -15,8 +15,8 @@ class {{class}} extends Model
     /**
      * @var array
      */
-    protected $dates = [
-        'cancelled_at',
+    protected $casts = [
+        'cancelled_at' => 'datetime',
     ];
 
     /**

--- a/src/Commands/stubs/subscription_model_l8.stub
+++ b/src/Commands/stubs/subscription_model_l8.stub
@@ -18,8 +18,8 @@ class {{class}} extends Model
     /**
      * @var array
      */
-    protected $dates = [
-        'cancelled_at',
+    protected $casts = [
+        'cancelled_at' => 'datetime',
     ];
 
     /**


### PR DESCRIPTION
This pull request changes the `Subscription` stub to use the `$casts` property instead of the dedicated `$dates` property for casting the `cancelled_at` to a `Carbon` instance.

`$dates` is no longer the recommended way of casting timestamps/datetimes, even the documentation recommends using `$casts` as it's infinitely more flexible.

https://laravel.com/docs/8.x/eloquent-mutators#date-casting